### PR TITLE
Separate knox's default authentication for login from the DRF's one 

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -8,10 +8,11 @@ Example `settings.py`
 ```python
 #...snip...
 # These are the default values if none are set
+from datetime import timedelta
 'REST_KNOX' = {
   'SECURE_HASH_ALGORITHM': 'cryptography.hazmat.primitives.hashes.SHA512',
   'AUTH_TOKEN_CHARACTER_LENGTH': 64,
-  'TOKEN_TTL': 10,
+  'TOKEN_TTL': timedelta(hours=10),
   'USER_SERIALIZER': 'knox.serializers.UserSerializer',
 }
 #...snip...

--- a/knox/settings.py
+++ b/knox/settings.py
@@ -1,11 +1,12 @@
 from datetime import timedelta
 from django.conf import settings
 from django.test.signals import setting_changed
-from rest_framework.settings import APISettings
+from rest_framework.settings import api_settings, APISettings
 
 USER_SETTINGS = getattr(settings, 'REST_KNOX', None)
 
 DEFAULTS = {
+    'LOGIN_AUTHENTICATION_CLASSES': api_settings.DEFAULT_AUTHENTICATION_CLASSES,
     'SECURE_HASH_ALGORITHM': 'cryptography.hazmat.primitives.hashes.SHA512',
     'AUTH_TOKEN_CHARACTER_LENGTH': 64,
     'TOKEN_TTL': timedelta(hours=10),

--- a/knox/views.py
+++ b/knox/views.py
@@ -2,7 +2,6 @@ from rest_framework import status
 from rest_framework.authentication import BasicAuthentication
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
-from rest_framework.settings import api_settings
 from rest_framework.views import APIView
 
 from knox.auth import TokenAuthentication

--- a/knox/views.py
+++ b/knox/views.py
@@ -12,7 +12,7 @@ from knox.settings import knox_settings
 UserSerializer = knox_settings.USER_SERIALIZER
 
 class LoginView(APIView):
-    authentication_classes = api_settings.DEFAULT_AUTHENTICATION_CLASSES
+    authentication_classes = knox_settings.LOGIN_AUTHENTICATION_CLASSES
     permission_classes = (IsAuthenticated,)
 
     def post(self, request, format=None):


### PR DESCRIPTION
To use knox's TokenAuthentication for DRF's default authentication, we need to separate knox's default authentication from the DRF's one.
