### PR TITLE
Don't assume User has an "username" field

### DIFF
--- a/knox/serializers.py
+++ b/knox/serializers.py
@@ -7,4 +7,4 @@ User = get_user_model()
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ('username', 'first_name', 'last_name',)
+        fields = (User.USERNAME_FIELD, 'first_name', 'last_name',)


### PR DESCRIPTION
Custom User models might not have an "username" field but they declare a USERNAME_FIELD variable which indicate which field to use instead.

See Django official example: https://docs.djangoproject.com/en/1.9/topics/auth/customizing/#a-full-example

In any case, thank you for this great app :-)