### PR TITLE
Fixed UserSerializer, so it accounts USERNAME_FIELD

### DIFF
--- a/knox/serializers.py
+++ b/knox/serializers.py
@@ -4,7 +4,9 @@ from rest_framework import serializers
 
 User = get_user_model()
 
+username_field = User.USERNAME_FIELD if hasattr(User, 'USERNAME_FIELD') else 'username'
+
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ('username', 'first_name', 'last_name',)
+        fields = (username_field, 'first_name', 'last_name',)


### PR DESCRIPTION
When using knox, if I have a custom model that doesn't use username as the username field, like say email_address, the UserSerializer fails because Django lets us have custom username fields. (See: https://docs.djangoproject.com/en/1.10/topics/auth/customizing/#django.contrib.auth.models.CustomUser.USERNAME_FIELD)
