### PR TITLE
Move UserSerializer definition into class

### DIFF
--- a/knox/views.py
+++ b/knox/views.py
@@ -1,6 +1,5 @@
 from rest_framework import status
-from rest_framework.authentication import BasicAuthentication
-from rest_framework.permissions import IsAuthenticated, AllowAny
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework.views import APIView
@@ -9,7 +8,6 @@ from knox.auth import TokenAuthentication
 from knox.models import AuthToken
 from knox.settings import knox_settings
 
-UserSerializer = knox_settings.USER_SERIALIZER
 
 class LoginView(APIView):
     authentication_classes = api_settings.DEFAULT_AUTHENTICATION_CLASSES
@@ -17,10 +15,12 @@ class LoginView(APIView):
 
     def post(self, request, format=None):
         token = AuthToken.objects.create(request.user)
+        UserSerializer = knox_settings.USER_SERIALIZER
         return Response({
             "user": UserSerializer(request.user).data,
             "token": token,
         })
+
 
 class LogoutView(APIView):
     authentication_classes = (TokenAuthentication,)
@@ -29,6 +29,7 @@ class LogoutView(APIView):
     def post(self, request, format=None):
         request._auth.delete()
         return Response(None, status=status.HTTP_204_NO_CONTENT)
+
 
 class LogoutAllView(APIView):
     '''


### PR DESCRIPTION
To avoid error when extending LoginView: django.core.exceptions.AppRegistryNotReady: Models aren't loaded yet
@James1345  Hope you find time to have a look at this :)