### PR TITLE
Test for invalid token length

### DIFF
--- a/knox/settings.py
+++ b/knox/settings.py
@@ -1,12 +1,11 @@
 from datetime import timedelta
 from django.conf import settings
 from django.test.signals import setting_changed
-from rest_framework.settings import api_settings, APISettings
+from rest_framework.settings import APISettings
 
 USER_SETTINGS = getattr(settings, 'REST_KNOX', None)
 
 DEFAULTS = {
-    'LOGIN_AUTHENTICATION_CLASSES': api_settings.DEFAULT_AUTHENTICATION_CLASSES,
     'SECURE_HASH_ALGORITHM': 'cryptography.hazmat.primitives.hashes.SHA512',
     'AUTH_TOKEN_CHARACTER_LENGTH': 64,
     'TOKEN_TTL': timedelta(hours=10),

--- a/knox/views.py
+++ b/knox/views.py
@@ -2,6 +2,7 @@ from django.contrib.auth.signals import user_logged_in, user_logged_out
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.settings import api_settings
 from rest_framework.views import APIView
 
 from knox.auth import TokenAuthentication
@@ -9,9 +10,8 @@ from knox.models import AuthToken
 from knox.settings import knox_settings
 
 
-
 class LoginView(APIView):
-    authentication_classes = knox_settings.LOGIN_AUTHENTICATION_CLASSES
+    authentication_classes = api_settings.DEFAULT_AUTHENTICATION_CLASSES
     permission_classes = (IsAuthenticated,)
 
     def post(self, request, format=None):

--- a/knox_project/urls.py
+++ b/knox_project/urls.py
@@ -16,8 +16,11 @@ Including another URLconf
 from django.conf.urls import include, url
 from django.contrib import admin
 
+from .views import RootView
+
 urlpatterns = [
     url(r'^api/', include('knox.urls')),
+    url(r'^api/$', RootView.as_view(), name="api-root"),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^', include(admin.site.urls)),
 ]

--- a/knox_project/views.py
+++ b/knox_project/views.py
@@ -1,0 +1,12 @@
+from knox.auth import TokenAuthentication
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+
+class RootView(APIView):
+    authentication_classes = (TokenAuthentication,)
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request):
+        return Response("api root")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3,7 +3,6 @@ import datetime
 
 from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
-
 from rest_framework.test import APIRequestFactory, APITestCase as TestCase
 
 from knox.auth import TokenAuthentication
@@ -95,3 +94,11 @@ class AuthTestCase(TestCase):
         self.assertEqual(
             token[:CONSTANTS.TOKEN_KEY_LENGTH],
             auth_token.token_key)
+
+    def test_invalid_token_length_returns_401_code(self):
+        invalid_token = "1" * (CONSTANTS.TOKEN_KEY_LENGTH - 1)
+        url = reverse('api-root')
+        self.client.credentials(HTTP_AUTHORIZATION=('Token %s' % invalid_token))
+        response = self.client.post(url, {}, format='json')
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.data, {"detail": "Invalid token."})


### PR DESCRIPTION
- add a test url/view "api-root"
- add a test for #20 where an invalid token length leads to a 500 response, but could't not reproduce it
- revert 73aef41 as I think it makes rest-knox less flexible, see my comment here: 73aef41#commitcomment-20145730