### PR TITLE
Fix SyntaxError in settings example in documentation

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -66,6 +66,6 @@ from yourapp.api.views import LoginView
 urlpatterns = [
      url(r'login/', LoginView.as_view(), name='knox_login'),
      url(r'logout/', knox_views.LogoutView.as_view(), name='knox_logout'),
-     url(r'logoutall/', knox_views.LogoutAllView.as_view()),
+     url(r'logoutall/', knox_views.LogoutAllView.as_view(), name='knox_logoutall'),
 ]
 ```

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -9,7 +9,7 @@ Example `settings.py`
 #...snip...
 # These are the default values if none are set
 from datetime import timedelta
-'REST_KNOX' = {
+REST_KNOX = {
   'SECURE_HASH_ALGORITHM': 'cryptography.hazmat.primitives.hashes.SHA512',
   'AUTH_TOKEN_CHARACTER_LENGTH': 64,
   'TOKEN_TTL': timedelta(hours=10),


### PR DESCRIPTION
There seems to be a small syntax error with the settings example where the documentation recommends assigning to a literal string. This commit just removes the quotes to make it a variable name.