### PR TITLE
Use os.urandom instead of OpenSSL.rand.bytes

### DIFF
--- a/knox/crypto.py
+++ b/knox/crypto.py
@@ -2,7 +2,7 @@ import binascii
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
-from OpenSSL.rand import bytes as generate_bytes
+from os import urandom as generate_bytes
 
 from knox.settings import knox_settings, CONSTANTS
 


### PR DESCRIPTION
Follows suggestion in pyOpenSSL changelog https://github.com/pyca/pyopenssl/blob/1eac0e8f9b3829c5401151fabb3f78453ad772a4/CHANGELOG.rst#backward-incompatible-changes-1