### PR TITLE
release notes for 3.1.1 bugfix release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,9 @@
 ######
+3.1.1
+######
+- use hmac.compare_digest instead of == for comparing hashes for more security
+
+######
 3.1.0
 ######
 - drop Django 1.8 support as djangorestframework did so too in v.3.7.0

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,5 +1,8 @@
 #Changelog
 
+## 3.1.1
+- use hmac.compare_digest instead of == for comparing hashes for more security
+
 ## 3.1.0
 - drop Django 1.8 support as djangorestframework did so too in v.3.7.0
 - build rest-knox on Django 1.11 and 2.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='3.1.0',
+    version='3.1.1',
     description='Authentication for django rest framework',
     long_description=long_description,
 


### PR DESCRIPTION
use hmac.compare_digest instead of == for comparing hashes for more security