### PR TITLE
Add fix and test for binascii.Error Odd-Length

### DIFF
--- a/knox/auth.py
+++ b/knox/auth.py
@@ -4,6 +4,8 @@ except ImportError:
     def compare_digest(a, b):
         return a == b
 
+import binascii
+
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 from django.utils import timezone
@@ -72,7 +74,7 @@ class TokenAuthentication(BaseAuthentication):
                     continue
             try:
                 digest = hash_token(token, auth_token.salt)
-            except TypeError:
+            except (TypeError, binascii.Error):
                 raise exceptions.AuthenticationFailed(msg)
             if compare_digest(digest, auth_token.digest):
                 return self.validate_user(auth_token)

--- a/knox/crypto.py
+++ b/knox/crypto.py
@@ -24,6 +24,9 @@ def hash_token(token, salt):
     '''
     Calculates the hash of a token and salt.
     input is unhexlified
+
+    token and salt must contain an even number of hex digits or
+    a binascii.Error exception will be raised
     '''
     digest = hashes.Hash(sha(), backend=default_backend())
     digest.update(binascii.unhexlify(token))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -136,3 +136,13 @@ class AuthTestCase(TestCase):
         response = self.client.post(url, {}, format='json')
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.data, {"detail": "Invalid token."})
+
+    def test_invalid_odd_length_token_returns_401_code(self):
+        user = User.objects.create_user('john.doe', 'root@localhost.com', 'test_pwd')
+        token = AuthToken.objects.create(user)
+        odd_length_token = token + '1'
+        url = reverse('api-root')
+        self.client.credentials(HTTP_AUTHORIZATION=('Token %s' % odd_length_token))
+        response = self.client.post(url, {}, format='json')
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.data, {"detail": "Invalid token."})


### PR DESCRIPTION
This fixes an edge case that only occurs when valid token is extended.

If I take a token a valid token (even length) and add a character to it, this will make an invalid, odd-length token. This token will pass the [first check][0], because the token is sliced to the correct length in the filter statement, but then an error occurs in [knox.crypto][1].


Fixes #46 

[0]: https://github.com/James1345/django-rest-knox/blob/45be9d1fc0c7963954803a3b01425f6b540f8673/knox/auth.py#L64

[1]: https://github.com/James1345/django-rest-knox/blob/45be9d1fc0c7963954803a3b01425f6b540f8673/knox/crypto.py#L29-L30