### PR TITLE
add: optional token limit per user object

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,4 +1,7 @@
-#Changelog
+# Changelog
+
+## 3.4.0
+- adds optional token limit
 
 ## 3.3.1
 - Ensure compatibility with Django 2.1 up to Python 3.7

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,8 @@ in to DRF. However, it overcomes some problems present in the default implementa
 
     Knox provides one token per call to the login view - allowing
     each client to have its own token which is deleted on the server side when the client
-    logs out.
+    logs out. Knox also provides an optional setting to limit the amount of tokens generated
+    per user.
 
     Knox also provides an option for a logged in client to remove *all* tokens
     that the server has - forcing all clients to re-authenticate.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -14,6 +14,7 @@ REST_KNOX = {
   'AUTH_TOKEN_CHARACTER_LENGTH': 64,
   'TOKEN_TTL': timedelta(hours=10),
   'USER_SERIALIZER': 'knox.serializers.UserSerializer',
+  'TOKEN_LIMIT_PER_USER': None,
   'AUTO_REFRESH': FALSE,
 }
 #...snip...
@@ -53,6 +54,10 @@ Setting the TOKEN_TTL to `None` will create tokens that never expire.
 
 Warning: setting a 0 or negative timedelta will create tokens that instantly expire,
 the system will not prevent you setting this.
+
+## TOKEN_LIMIT_PER_USER
+This allows you to control how many tokens can be issued per user.
+By default this option is disabled and set to `None` -- thus no limit.
 
 ## USER_SERIALIZER
 This is the reference to the class used to serialize the `User` objects when

--- a/knox/settings.py
+++ b/knox/settings.py
@@ -10,6 +10,7 @@ DEFAULTS = {
     'AUTH_TOKEN_CHARACTER_LENGTH': 64,
     'TOKEN_TTL': timedelta(hours=10),
     'USER_SERIALIZER': None,
+    'TOKEN_LIMIT_PER_USER': None,
     'AUTO_REFRESH': False,
 }
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from django.utils.six.moves import reload_module
 from django.contrib.auth import get_user_model
 from django.test import override_settings
-from knox import auth
+from knox import auth, views
 
 try:
     # For django >= 2.0
@@ -38,6 +38,11 @@ def get_basic_auth_header(username, password):
 auto_refresh_knox = knox_settings.defaults.copy()
 auto_refresh_knox["AUTO_REFRESH"] = True
 
+token_user_limit_knox = knox_settings.defaults.copy()
+token_user_limit_knox["TOKEN_LIMIT_PER_USER"] = 10
+
+user_serializer_knox = knox_settings.defaults.copy()
+user_serializer_knox["USER_SERIALIZER"] = UserSerializer
 
 class AuthTestCase(TestCase):
 
@@ -73,15 +78,18 @@ class AuthTestCase(TestCase):
         self.assertNotIn(username_field, response.data)
 
     def test_login_returns_serialized_token_and_username_field(self):
-        self.assertEqual(AuthToken.objects.count(), 0)
-        url = reverse('knox_login')
-        self.client.credentials(
-            HTTP_AUTHORIZATION=get_basic_auth_header(self.username, self.password)
-        )
-        knox_settings.USER_SERIALIZER = UserSerializer
-        response = self.client.post(url, {}, format='json')
+
+        with override_settings(REST_KNOX=user_serializer_knox):
+            reload_module(views)
+            self.assertEqual(AuthToken.objects.count(), 0)
+            url = reverse('knox_login')
+            self.client.credentials(
+                HTTP_AUTHORIZATION=get_basic_auth_header(self.username, self.password)
+            )
+            response = self.client.post(url, {}, format='json')
+            self.assertEqual(user_serializer_knox["USER_SERIALIZER"], UserSerializer)
+        reload_module(views)
         self.assertEqual(response.status_code, 200)
-        self.assertNotEqual(knox_settings.USER_SERIALIZER, None)
         self.assertIn('token', response.data)
         username_field = self.user.USERNAME_FIELD
         self.assertIn('user', response.data)
@@ -254,3 +262,37 @@ class AuthTestCase(TestCase):
 
         self.assertTrue(self.signal_was_called)
 
+    def test_exceed_token_amount_per_user(self):
+
+        with override_settings(REST_KNOX=token_user_limit_knox):
+            reload_module(views)
+            for _ in range(10):
+                token = AuthToken.objects.create(user=self.user)
+            url = reverse('knox_login')
+            self.client.credentials(
+                HTTP_AUTHORIZATION=get_basic_auth_header(self.username, self.password)
+            )
+            response = self.client.post(url, {}, format='json')
+        reload_module(views)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.data, {"error": "Maximum amount of tokens allowed per user exceeded."})
+
+    def test_does_not_exceed_on_expired_keys(self):
+
+        with override_settings(REST_KNOX=token_user_limit_knox):
+            reload_module(views)
+            for _ in range(9):
+                token = AuthToken.objects.create(user=self.user)
+            AuthToken.objects.create(user=self.user, expires=timedelta(seconds=0))
+            # now 10 keys, but only 9 valid so request should succeed.
+            url = reverse('knox_login')
+            self.client.credentials(
+                HTTP_AUTHORIZATION=get_basic_auth_header(self.username, self.password)
+            )
+            response = self.client.post(url, {}, format='json')
+            failed_response = self.client.post(url, {}, format='json')
+        reload_module(views)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('token', response.data)
+        self.assertEqual(failed_response.status_code, 403)
+        self.assertEqual(failed_response.data, {"error": "Maximum amount of tokens allowed per user exceeded."})


### PR DESCRIPTION
@belugame This is what I got thus far. I have verified the functionality manually -- it works but I am having trouble with the test not respecting the overridden `TOKEN_LIMIT`, thus the test fails -- I figured the default settings value should be `None` since this option does come with a performance cost and is not needed by everyone.

I mean I could just set `knox_settings.TOKEN_LIMIT = 10` inside the testcase but.. is that the correct way?

Related: https://github.com/James1345/django-rest-knox/issues/108