### PR TITLE
Suggestion: make UserSerializer none by default

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,5 +1,9 @@
 #Changelog
 
+## 3.x.x
+- **Breaking changes**: Successful authentication **ONLY** returns `Token` object by default now. 
+`USER_SERIALIZER` must be overridden to return custom data.
+
 ## 3.2.0
 - Introduce new setting AUTO_REFRESH for controlling if token expiry time should be extended automatically
 

--- a/docs/views.md
+++ b/docs/views.md
@@ -13,13 +13,17 @@ schemes. If you would like to use a different authentication scheme to the
 default, you can extend this class to provide your own value for
 `authentication_classes`
 
-When it receives an authenticated request, it will return json
-- `user` an object representing the user that was authenticated
-- `token` the token that should be used for any token
+---
+When the endpoint authenticates a request, a json object will be returned 
+containing the `token` key along with the actual value for the key by default.
 
-The returned `user` object is serialized using the `USER_SERIALIZER` setting.
-If this setting is not changed, the default serializer returns the user's
-`first_name`, `last_name` and `username`.
+> *This is because `USER_SERIALIZER` setting is `None` by default.*
+
+If you wish to return custom data upon successful authentication
+like `first_name`, `last_name`, and `username` then the included `UserSerializer`
+class can be used inside `REST_KNOX` settings by adding `knox.serializers.UserSerializer`
+---
+
 
 Obviously, if your app uses a custom user model that does not have these fields,
 a custom serializer must be used.

--- a/knox/serializers.py
+++ b/knox/serializers.py
@@ -9,4 +9,4 @@ username_field = User.USERNAME_FIELD if hasattr(User, 'USERNAME_FIELD') else 'us
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = (username_field, 'first_name', 'last_name',)
+        fields = (username_field,)

--- a/knox/settings.py
+++ b/knox/settings.py
@@ -9,7 +9,7 @@ DEFAULTS = {
     'SECURE_HASH_ALGORITHM': 'cryptography.hazmat.primitives.hashes.SHA512',
     'AUTH_TOKEN_CHARACTER_LENGTH': 64,
     'TOKEN_TTL': timedelta(hours=10),
-    'USER_SERIALIZER': 'knox.serializers.UserSerializer',
+    'USER_SERIALIZER': None,
     'AUTO_REFRESH': False,
 }
 

--- a/knox/views.py
+++ b/knox/views.py
@@ -19,6 +19,10 @@ class LoginView(APIView):
         user_logged_in.send(sender=request.user.__class__, request=request, user=request.user)
         UserSerializer = knox_settings.USER_SERIALIZER
         context = {'request': self.request, 'format': self.format_kwarg, 'view': self}
+        if UserSerializer is None:
+            return Response(
+                {'token': token}
+            )
         return Response({
             'user': UserSerializer(request.user, context=context).data,
             'token': token,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -22,6 +22,7 @@ from rest_framework.test import (
 from knox.auth import TokenAuthentication
 from knox.models import AuthToken
 from knox.settings import CONSTANTS, knox_settings
+from knox.serializers import UserSerializer
 
 User = get_user_model()
 root_url = reverse('api-root')
@@ -54,6 +55,34 @@ class AuthTestCase(TestCase):
             self.client.post(url, {}, format='json')
         self.assertEqual(AuthToken.objects.count(), 5)
         self.assertTrue(all(e.token_key for e in AuthToken.objects.all()))
+
+    def test_login_returns_serialized_token(self):
+        self.assertEqual(AuthToken.objects.count(), 0)
+        url = reverse('knox_login')
+        self.client.credentials(
+            HTTP_AUTHORIZATION=get_basic_auth_header(self.username, self.password)
+        )
+        response = self.client.post(url, {}, format='json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(knox_settings.USER_SERIALIZER, None)
+        self.assertIn('token', response.data)
+        username_field = self.user.USERNAME_FIELD
+        self.assertNotIn(username_field, response.data)
+
+    def test_login_returns_serialized_token_and_username_field(self):
+        self.assertEqual(AuthToken.objects.count(), 0)
+        url = reverse('knox_login')
+        self.client.credentials(
+            HTTP_AUTHORIZATION=get_basic_auth_header(self.username, self.password)
+        )
+        knox_settings.USER_SERIALIZER = UserSerializer
+        response = self.client.post(url, {}, format='json')
+        self.assertEqual(response.status_code, 200)
+        self.assertNotEqual(knox_settings.USER_SERIALIZER, None)
+        self.assertIn('token', response.data)
+        username_field = self.user.USERNAME_FIELD
+        self.assertIn('user', response.data)
+        self.assertIn(username_field, response.data['user'])
 
     def test_logout_deletes_keys(self):
         self.assertEqual(AuthToken.objects.count(), 0)


### PR DESCRIPTION
Currently `UserSerializer` hardcodes `first_name` and `last_name` on all `User` objects to be serialized as output upon successful authentication even though it does check for `USERNAME_FIELD` on the `User` object.

I believe this could be done a tad more generic -- especially checking for custom `USERNAME_FIELD` chances are that you are not even using the first_name and last_name fields on the User model. So I suggest therefore only return the `Token` and have `UserSerializer` be `None` by default:

```{"token": "9944b09199c62bcf9418ad846dd0e4bbdfc6ee4b9836F45E23A345"}```

I cannot see why one would always return the `USERNAME_FIELD` again in the response. We already supplied it when we requested the token to begin with. I am saying this for “most” cases, now there might be cases where you want it, so the option should stay but disabled by default.