### PR TITLE
[DONT MERGE] feature: add json authentication view

### DIFF
--- a/knox/serializers.py
+++ b/knox/serializers.py
@@ -1,4 +1,4 @@
-from django.contrib.auth import get_user_model
+from django.contrib.auth import authenticate, get_user_model
 
 from rest_framework import serializers
 
@@ -10,3 +10,43 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = (username_field, 'first_name', 'last_name',)
+
+
+class TokenSerializer(serializers.Serializer):
+
+    @property
+    def username_field(self):
+        try:
+            username_field = get_user_model().USERNAME_FIELD
+        except AttributeError:
+            username_field = 'username'
+        return username_field
+
+    def __init__(self, *args, **kwargs):
+        super(TokenSerializer, self).__init__(*args, **kwargs)
+        self.fields[self.username_field] = serializers.CharField()
+        self.fields['password'] = serializers.CharField(write_only=True)
+
+    def validate(self, attrs):
+
+        credentials = {
+            username_field: attrs.get(self.username_field),
+            'password': attrs.get('password')
+        }
+
+        if all(credentials.values()):
+            user = authenticate(**credentials)
+            if user:
+                if not user.is_active:
+                    msg = 'User account is disabled.'
+                    raise serializers.ValidationError(msg)
+                return {
+                    'user': user
+                }
+            else:
+                msg = 'Unable to login with provided credentials.'
+                raise serializers.ValidationError(msg)
+        else:
+            msg = 'Must include "{username_field}" and "password".'
+            msg = msg.format(username_field=self.username_field)
+            raise serializers.ValidationError(msg)

--- a/knox_project/urls.py
+++ b/knox_project/urls.py
@@ -7,8 +7,10 @@ except ImportError:
     path = url
 
 from .views import RootView
+from knox.views import obtain_token
 
 urlpatterns = [
     path(r'^api/', include('knox.urls')),
+    path(r'^api/auth/$', obtain_token, name="knox-api-auth"),
     path(r'^api/$', RootView.as_view(), name="api-root"),
 ]

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -21,6 +21,7 @@ from rest_framework.test import (
 
 from knox.auth import TokenAuthentication
 from knox.models import AuthToken
+from knox.serializers import TokenSerializer
 from knox.settings import CONSTANTS, knox_settings
 
 User = get_user_model()
@@ -204,3 +205,61 @@ class AuthTestCase(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(original_expiry, AuthToken.objects.get().expires)
+
+    def test_authentication_serializer(self):
+
+        serializer = TokenSerializer(data={})
+        is_valid = serializer.is_valid()
+        expected_errors = {
+            'username': ['This field is required.'],
+            'password': ['This field is required.']
+        }
+        self.assertFalse(is_valid)
+        self.assertEqual(serializer.errors, expected_errors)
+
+    def test_authentication_json_post(self):
+
+        credentials = {
+            'username': self.username,
+            'password': self.password
+        }
+        url = reverse('knox-api-auth')
+        response = self.client.post(url, credentials, format='json')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('token', response.data)
+
+    def test_authentication_json_post_invalid_credentials(self):
+
+        credentials = {
+            'username': self.username,
+            'password': "fffff"
+        }
+        url = reverse('knox-api-auth')
+        response = self.client.post(url, credentials, format='json')
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual({'non_field_errors': ['Unable to login with provided credentials.']}, response.data)
+
+    def test_authentication_json_post_non_existent_user(self):
+
+        credentials = {
+            'username': 'idontexist',
+            'password': 'idontwork'
+        }
+        url = reverse('knox-api-auth')
+        response = self.client.post(url, credentials, format='json')
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual({'non_field_errors': ['Unable to login with provided credentials.']}, response.data)
+
+    def test_authentication_json_post_missing_field(self):
+
+        credentials = {}
+        url = reverse('knox-api-auth')
+        response = self.client.post(url, credentials, format='json')
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            {
+                'username': ['This field is required.'],
+                'password': ['This field is required.']
+            },
+            response.data
+        )


### PR DESCRIPTION
First off, I am not sure why this doesnt already exist, maybe it was intentional but anyway here it is.
This is allows a `json` request with username and password to be sent to an endpoint instead of using Basic HTTP Authentication.

For now this is simply disabled by default, ive added some tests but I reckon more is required since it aims to authenticate a user -- even though it relies on the `authenticate()` from django to do it.

* [ ] This PR does not incorporate another PRs Ive sent just yet, because they are still pending an answer: https://github.com/James1345/django-rest-knox/pull/109
* [ ] docs are not updated yet