### PR TITLE
Add docker support to run the tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,3 +41,11 @@ problems present in the default implementation:
 
 More information can be found in the
 `Documentation <http://james1345.github.io/django-rest-knox/>`__
+
+Run the tests locally
+---------------------
+
+If you need to debug a test locally and if you have `docker <https://www.docker.com/>`__ installed:
+
+simply run the ``./docker-run-test.sh`` script and it will run the test suite in every Python /
+Django versions.

--- a/README.rst
+++ b/README.rst
@@ -49,3 +49,6 @@ If you need to debug a test locally and if you have `docker <https://www.docker.
 
 simply run the ``./docker-run-test.sh`` script and it will run the test suite in every Python /
 Django versions.
+
+You could also simply run regular ``tox`` in the root folder as well, but that would make testing the matrix of
+Python / Django versions a bit more tricky.

--- a/docker-run-tests.sh
+++ b/docker-run-tests.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+MOUNT_FOLDER=/django-rest-knox
+docker run --rm -it -v $(pwd):$MOUNT_FOLDER -w $MOUNT_FOLDER themattrix/tox

--- a/docker-run-tests.sh
+++ b/docker-run-tests.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-MOUNT_FOLDER=/django-rest-knox
+MOUNT_FOLDER=/app
 docker run --rm -it -v $(pwd):$MOUNT_FOLDER -w $MOUNT_FOLDER themattrix/tox


### PR DESCRIPTION
This was handy to run the all matrix of tests locally and could help others.

On the other hand I would totally understand if you don't like the Docker dependency or don't want to maintain something like this ✌️ 