### PR TITLE
Fix #128 Replace path with re_path in test urls

### DIFF
--- a/knox_project/urls.py
+++ b/knox_project/urls.py
@@ -1,14 +1,14 @@
 try:
     # For django >= 2.0
-    from django.urls import include, path
+    from django.urls import include, re_path
 except ImportError:
     # For django < 2.0
     from django.conf.urls import include, url
-    path = url
+    re_path = url
 
 from .views import RootView
 
 urlpatterns = [
-    path(r'^api/', include('knox.urls')),
-    path(r'^api/$', RootView.as_view(), name="api-root"),
+    re_path(r'^api/', include('knox.urls')),
+    re_path(r'^api/$', RootView.as_view(), name="api-root"),
 ]


### PR DESCRIPTION
`path` will trigger a warning when used with a regex while
`re_path` is what should be used instead.