### PR TITLE
Limit deploy-to-pypi to single python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ deploy:
   on:
     tags: true
     repo: James1345/django-rest-knox
+    python: "3.7"
   only:
     - master
   distributions: "sdist bdist_wheel"


### PR DESCRIPTION
Fix for #138

We want to avoid that each item in the test matrix triggers a deployment
to pypi. This limits the deploy job to when the python version is 3.7,
hence it should only run once.