### PR TITLE
Make the user serializer configurable for LoginView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+3.5.1
+=====
+
+- The user serializer for each `LoginView`is now dynamic
+
+
 3.5.0
 =====
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.5.1
+
+- The user serializer for each `LoginView`is now dynamic
+
 ## 3.5.0
 
 - The context, token TTL and tokens per user settings in `LoginView` are now dynamic

--- a/docs/views.md
+++ b/docs/views.md
@@ -18,6 +18,7 @@ helper methods:
 - `get_context`, to change the context passed to the `UserSerializer`
 - `get_token_ttl`, to change the token ttl
 - `get_token_limit_per_user`, to change the number of tokens available for a user
+- `get_user_serializer_class`, to change the class used for serializing the user
 
 ---
 When the endpoint authenticates a request, a json object will be returned 

--- a/knox/views.py
+++ b/knox/views.py
@@ -25,6 +25,9 @@ class LoginView(APIView):
     def get_token_limit_per_user(self):
         return knox_settings.TOKEN_LIMIT_PER_USER
 
+    def get_user_serializer_class(self):
+        return knox_settings.USER_SERIALIZER
+
     def post(self, request, format=None):
         token_limit_per_user = self.get_token_limit_per_user()
         if token_limit_per_user is not None:
@@ -39,11 +42,11 @@ class LoginView(APIView):
         token = AuthToken.objects.create(request.user, token_ttl)
         user_logged_in.send(sender=request.user.__class__,
                             request=request, user=request.user)
-        UserSerializer = knox_settings.USER_SERIALIZER
+        UserSerializer = self.get_user_serializer_class()
         if UserSerializer is None:
-            return Response(
-                {'token': token}
-            )
+            return Response({
+                'token': token
+            })
         context = self.get_context()
         return Response({
             'user': UserSerializer(request.user, context=context).data,


### PR DESCRIPTION
So that's easily overridable when hosting more than one instance
of LoginView in the same project.