### PR TITLE
adds flake8 to tox ev during test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,14 @@
 [tox]
 envlist =
+   flake8,
    py{27,34,35,36}-django111,
    py{34,35,36}-django20,
    py{35,36,37}-django21,
+
+[testenv:flake8]
+deps = flake8
+changedir = {toxinidir}
+commands = flake8 knox
 
 [testenv]
 commands =


### PR DESCRIPTION
Not sure if it was intentional to not include it, but this adds flake8 to tox so its run during `./docker-run-tests.sh` it also checks syntax.

