### PR TITLE
fixes #154 -- adds isort

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,7 @@
+[settings]
+combine_as_imports = true
+default_section = THIRDPARTY
+include_trailing_comma = true
+known_first_party = knox
+multi_line_output = 5
+not_skip = __init__.py

--- a/knox/admin.py
+++ b/knox/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+
 from knox import models
 
 

--- a/knox/auth.py
+++ b/knox/auth.py
@@ -6,14 +6,12 @@ except ImportError:
 
 import binascii
 
-from django.utils.translation import ugettext_lazy as _
-from django.utils import timezone
 from django.contrib.auth import get_user_model
-
+from django.utils import timezone
+from django.utils.translation import ugettext_lazy as _
 from rest_framework import exceptions
 from rest_framework.authentication import (
-    BaseAuthentication,
-    get_authorization_header
+    BaseAuthentication, get_authorization_header,
 )
 
 from knox.crypto import hash_token

--- a/knox/crypto.py
+++ b/knox/crypto.py
@@ -1,10 +1,10 @@
 import binascii
+from os import urandom as generate_bytes
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
-from os import urandom as generate_bytes
 
-from knox.settings import knox_settings, CONSTANTS
+from knox.settings import CONSTANTS, knox_settings
 
 sha = knox_settings.SECURE_HASH_ALGORITHM
 

--- a/knox/migrations/0001_initial.py
+++ b/knox/migrations/0001_initial.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
 from django.conf import settings
+from django.db import migrations, models
 
 
 class Migration(migrations.Migration):

--- a/knox/migrations/0002_auto_20150916_1425.py
+++ b/knox/migrations/0002_auto_20150916_1425.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
 from django.conf import settings
+from django.db import migrations, models
 
 
 class Migration(migrations.Migration):

--- a/knox/migrations/0003_auto_20150916_1526.py
+++ b/knox/migrations/0003_auto_20150916_1526.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations, models
 
 
 class Migration(migrations.Migration):

--- a/knox/serializers.py
+++ b/knox/serializers.py
@@ -1,5 +1,4 @@
 from django.contrib.auth import get_user_model
-
 from rest_framework import serializers
 
 User = get_user_model()

--- a/knox/settings.py
+++ b/knox/settings.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+
 from django.conf import settings
 from django.test.signals import setting_changed
 from rest_framework.settings import APISettings

--- a/knox/views.py
+++ b/knox/views.py
@@ -1,6 +1,5 @@
 from django.contrib.auth.signals import user_logged_in, user_logged_out
 from django.utils import timezone
-
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response

--- a/knox_project/views.py
+++ b/knox_project/views.py
@@ -1,7 +1,8 @@
-from knox.auth import TokenAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
+from knox.auth import TokenAuthentication
 
 
 class RootView(APIView):

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 # Always prefer setuptools over distutils
-from setuptools import setup, find_packages
 # To use a consistent encoding
 from codecs import open
 from os import path
+
+from setuptools import find_packages, setup
 
 here = path.abspath(path.dirname(__file__))
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,10 +1,18 @@
 import base64
 from datetime import datetime, timedelta
 
-from django.utils.six.moves import reload_module
 from django.contrib.auth import get_user_model
 from django.test import override_settings
+from django.utils.six.moves import reload_module
+from freezegun import freeze_time
+from rest_framework.test import APIRequestFactory, APITestCase as TestCase
+
 from knox import auth, views
+from knox.auth import TokenAuthentication
+from knox.models import AuthToken
+from knox.serializers import UserSerializer
+from knox.settings import CONSTANTS, knox_settings
+from knox.signals import token_expired
 
 try:
     # For django >= 2.0
@@ -12,19 +20,6 @@ try:
 except ImportError:
     # For django < 2.0
     from django.conf.urls import reverse
-
-from freezegun import freeze_time
-
-from rest_framework.test import (
-    APIRequestFactory,
-    APITestCase as TestCase
-)
-
-from knox.auth import TokenAuthentication
-from knox.signals import token_expired
-from knox.models import AuthToken
-from knox.settings import CONSTANTS, knox_settings
-from knox.serializers import UserSerializer
 
 User = get_user_model()
 root_url = reverse('api-root')

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,24 @@
 [tox]
 envlist =
-   flake8,
-   py{27,34,35,36}-django111,
-   py{34,35,36}-django20,
-   py{35,36,37}-django21,
+    isort
+    flake8,
+    py{27,34,35,36}-django111,
+    py{34,35,36}-django20,
+    py{35,36,37}-django21,
 
 [testenv:flake8]
 deps = flake8
 changedir = {toxinidir}
 commands = flake8 knox
+
+[testenv:isort]
+deps = isort
+changedir = {toxinidir}
+commands = isort --recursive --check-only --diff \ 
+    knox \
+    knox_project/views.py \
+    setup.py \
+    tests
 
 [testenv]
 commands =
@@ -23,6 +33,7 @@ deps =
     django21: Django>=2.1,<2.2
     django-nose
     markdown<3.0
+    isort
     djangorestframework
     freezegun
     mkdocs


### PR DESCRIPTION
Hello, 
Adds isort to testenv and sorts all imports. Closes https://github.com/James1345/django-rest-knox/issues/154 :cat2:

We might want to add some extra rules, personally I run these in my projects:
```
[isort]
combine_as_imports = true
default_section = THIRDPARTY
include_trailing_comma = true
known_first_party = django
line_length = 79
multi_line_output = 5
not_skip = __init__.py
```

Also, this does not test the imports in `tests/`. Let me know if that feels like something you might want.

Cheers mates