### PR TITLE
fixes #156 -- provide token refresh endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ to fit these new changes.
 
 - `AuthToken` model field has been changed from `expires` to `expiry`
 - Successful login now always returns a `expiry` field for when the token expires
+- New endpoint allows refreshing a token to increase its expiration date. See the documentation for more information
+- Reverse url for `LogoutAllView` has been renamed to `knox_logout_all` and the url changed to `/api/auth/logout/all`
 
 3.6.0
 =====

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -17,7 +17,8 @@ Depending on your usage you might have to adjust your code
 to fit these new changes.
 
 - `AuthToken` model field has been changed from `expires` to `expiry`
-- Successful login now always returns a `expiry` field for when the token expires
+- New endpoint allows refreshing a token to increase its expiration date. See the documentation for more information
+- Reverse url for `LogoutAllView` has been renamed to `knox_logout_all` and the url changed to `/api/auth/logout/all`
 
 ## 3.6.0
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -13,6 +13,7 @@ REST_KNOX = {
   'SECURE_HASH_ALGORITHM': 'cryptography.hazmat.primitives.hashes.SHA512',
   'AUTH_TOKEN_CHARACTER_LENGTH': 64,
   'TOKEN_TTL': timedelta(hours=10),
+  'ENABLE_REFRESH_ENDPOINT': False,
   'USER_SERIALIZER': 'knox.serializers.UserSerializer',
   'TOKEN_LIMIT_PER_USER': None,
   'AUTO_REFRESH': FALSE,
@@ -54,6 +55,15 @@ Setting the TOKEN_TTL to `None` will create tokens that never expire.
 
 Warning: setting a 0 or negative timedelta will create tokens that instantly expire,
 the system will not prevent you setting this.
+
+## ENABLE_REFRESH_ENDPOINT
+Set this setting to `True` to allow users to extend the life of a token. However this endpoint is disabled by default.
+
+Send an authenticated `POST` request to increase token with the amount
+set for `TOKEN_TTL`.
+
+**Warning**: This setting depends on `TOKEN_TTL` being set to not `None`. 
+Otherwise it will raise a `ValueError` which in turn will cause an internal server error (500).
 
 ## TOKEN_LIMIT_PER_USER
 This allows you to control how many tokens can be issued per user.

--- a/docs/urls.md
+++ b/docs/urls.md
@@ -1,4 +1,4 @@
-#URLS `knox.urls`
+# URLS `knox.urls`
 Knox provides a url config ready with its three default views routed.
 
 This can easily be included in your url config:
@@ -17,12 +17,14 @@ The views would then acessible as:
 
 - `/api/auth/login` -> `LoginView`
 - `/api/auth/logout` -> `LogoutView`
-- `/api/auth/logoutall` -> `LogoutAllView`
+- `/api/auth/logout/all` -> `LogoutAllView`
+- `/api/auth/refresh` -> `TokenRefreshView`
 
 they can also be looked up by name:
 
 ```python
 reverse('knox_login')
 reverse('knox_logout')
-reverse('knox_logoutall')
+reverse('knox_logout_all')
+reverse('knox_refresh')
 ```

--- a/docs/views.md
+++ b/docs/views.md
@@ -53,3 +53,11 @@ system and can no longer be used to authenticate.
 **Note** It is not recommended to alter the Logout views. They are designed
 specifically for token management, and to respond to Knox authentication.
 Modified forms of the class may cause unpredictable results.
+
+## TokenRefreshView
+This view accepts only a post request with an empty body.
+On a successful request, the token used to authenticate will be refreshed and its expiry will be extended by the amount set in `TOKEN_TTL`.
+
+The response body includes an expiry key with a timestamp that represents the token's new expiry. 
+
+**Note**: To enable this view set `ENABLE_REFRESH_ENDPOINT` to `True`.

--- a/knox/settings.py
+++ b/knox/settings.py
@@ -9,6 +9,7 @@ USER_SETTINGS = getattr(settings, 'REST_KNOX', None)
 DEFAULTS = {
     'SECURE_HASH_ALGORITHM': 'cryptography.hazmat.primitives.hashes.SHA512',
     'AUTH_TOKEN_CHARACTER_LENGTH': 64,
+    'ENABLE_REFRESH_ENDPOINT': False,
     'TOKEN_TTL': timedelta(hours=10),
     'USER_SERIALIZER': None,
     'TOKEN_LIMIT_PER_USER': None,

--- a/knox/urls.py
+++ b/knox/urls.py
@@ -4,6 +4,7 @@ from knox import views
 
 urlpatterns = [
     url(r'login/', views.LoginView.as_view(), name='knox_login'),
-    url(r'logout/', views.LogoutView.as_view(), name='knox_logout'),
-    url(r'logoutall/', views.LogoutAllView.as_view(), name='knox_logoutall'),
+    url(r'logout/$', views.LogoutView.as_view(), name='knox_logout'),
+    url(r'logout/all/$', views.LogoutAllView.as_view(), name='knox_logout_all'),
+    url(r'refresh/$', views.TokenRefreshView.as_view(), name='knox_refresh')
 ]


### PR DESCRIPTION
Hi,
First draft of whats discussed in #156, I ended up going for a simpler approach than integrating drf throttling due to the points laid out by @johnraz. However as suggested by #157 we should prolly take a look at that aswell since at least I would expect drf throttling to also apply to our views. (different issue tho).

As discussed these endpoints are optional, and they are not exposed by default unless `TOKEN_TTL` and `AUTO_REFRESH` are set. Where `AUTO_REFRESH` is `False` by default, thus off. 

Let me know what you think