### PR TITLE
Add setting for expiry format, add helper methods in login view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.1
+
+- Fix for tox config to build Django 2.2 on python 3.6
+
 ## 4.0.0
 
 **BREAKING** This is a major release version because it

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -9,6 +9,7 @@ Example `settings.py`
 #...snip...
 # These are the default values if none are set
 from datetime import timedelta
+from rest_framework.settings import api_settings
 REST_KNOX = {
   'SECURE_HASH_ALGORITHM': 'cryptography.hazmat.primitives.hashes.SHA512',
   'AUTH_TOKEN_CHARACTER_LENGTH': 64,
@@ -16,6 +17,7 @@ REST_KNOX = {
   'USER_SERIALIZER': 'knox.serializers.UserSerializer',
   'TOKEN_LIMIT_PER_USER': None,
   'AUTO_REFRESH': False,
+  'EXPIRY_DATETIME_FORMAT': api_settings.DATETME_FORMAT,
 }
 #...snip...
 ```
@@ -73,6 +75,14 @@ in the database.
 
 ## AUTH_HEADER_PREFIX
 This is the Authorization header value prefix. The default is `Token`
+
+## EXPIRY_DATETIME_FORMAT
+This is the expiry datetime format returned in the login view. The default is the
+[DATETIME_FORMAT][DATETIME_FORMAT] of Django REST framework. May be any of `None`, `iso-8601`
+or a Python [strftime format][strftime format] string.
+
+[DATETIME_FORMAT]: https://www.django-rest-framework.org/api-guide/settings/#date-and-time-formatting
+[strftime format]: https://docs.python.org/3/library/time.html#time.strftime
 
 # Constants `knox.settings`
 Knox also provides some constants for information. These must not be changed in

--- a/docs/views.md
+++ b/docs/views.md
@@ -15,13 +15,36 @@ default, you can extend this class to provide your own value for
 
 It is possible to customize LoginView behaviour by overriding the following
 helper methods:
-- `get_context`, to change the context passed to the `UserSerializer`
-- `get_token_ttl`, to change the token ttl
-- `get_token_limit_per_user`, to change the number of tokens available for a user
-- `get_user_serializer_class`, to change the class used for serializing the user
+- `get_context(self)`, to change the context passed to the `UserSerializer`
+- `get_token_ttl(self)`, to change the token ttl
+- `get_token_limit_per_user(self)`, to change the number of tokens available for a user
+- `get_user_serializer_class(self)`, to change the class used for serializing the user
+- `get_expiry_datetime_format(self)`, to change the datetime format used for expiry
+- `format_expiry_datetime(self, expiry)`, to format the expiry `datetime` object at your convinience
+
+Finally, if none of these helper methods are sufficient, you can also override `get_post_response_data`
+to return a fully customized payload.
+
+```python
+...snip...
+    def get_post_response_data(self, request, token, instance):
+        UserSerializer = self.get_user_serializer_class()
+
+        data = {
+            'expiry': self.format_expiry_datetime(instance.expiry),
+            'token': token
+        }
+        if UserSerializer is not None:
+            data["user"] = UserSerializer(
+                request.user,
+                context=self.get_context()
+            ).data
+        return data
+...snip...
+```
 
 ---
-When the endpoint authenticates a request, a json object will be returned 
+When the endpoint authenticates a request, a json object will be returned
 containing the `token` key along with the actual value for the key by default.
 The success response also includes a `expiry` key with a timestamp for when
 the token expires.

--- a/knox/settings.py
+++ b/knox/settings.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from django.conf import settings
 from django.test.signals import setting_changed
-from rest_framework.settings import APISettings
+from rest_framework.settings import APISettings, api_settings
 
 USER_SETTINGS = getattr(settings, 'REST_KNOX', None)
 
@@ -15,6 +15,7 @@ DEFAULTS = {
     'AUTO_REFRESH': False,
     'MIN_REFRESH_INTERVAL': 60,
     'AUTH_HEADER_PREFIX': 'Token',
+    'EXPIRY_DATETIME_FORMAT': api_settings.DATETIME_FORMAT,
 }
 
 IMPORT_STRINGS = {

--- a/knox/views.py
+++ b/knox/views.py
@@ -3,6 +3,7 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.serializers import DateTimeField
 from rest_framework.settings import api_settings
 from rest_framework.views import APIView
 
@@ -27,6 +28,9 @@ class LoginView(APIView):
     def get_user_serializer_class(self):
         return knox_settings.USER_SERIALIZER
 
+    def get_expiry_datetime_format(self):
+        return knox_settings.EXPIRY_DATETIME_FORMAT
+
     def post(self, request, format=None):
         token_limit_per_user = self.get_token_limit_per_user()
         if token_limit_per_user is not None:
@@ -42,9 +46,11 @@ class LoginView(APIView):
         user_logged_in.send(sender=request.user.__class__,
                             request=request, user=request.user)
         UserSerializer = self.get_user_serializer_class()
+        datetime_format = self.get_expiry_datetime_format()
 
         data = {
-            'expiry': instance.expiry,
+            'expiry': DateTimeField(
+                format=datetime_format).to_representation(instance.expiry),
             'token': token
         }
         if UserSerializer is not None:

--- a/knox/views.py
+++ b/knox/views.py
@@ -31,6 +31,24 @@ class LoginView(APIView):
     def get_expiry_datetime_format(self):
         return knox_settings.EXPIRY_DATETIME_FORMAT
 
+    def format_expiry_datetime(self, expiry):
+        datetime_format = self.get_expiry_datetime_format()
+        return DateTimeField(format=datetime_format).to_representation(expiry)
+
+    def get_post_response_data(self, request, token, instance):
+        UserSerializer = self.get_user_serializer_class()
+
+        data = {
+            'expiry': self.format_expiry_datetime(instance.expiry),
+            'token': token
+        }
+        if UserSerializer is not None:
+            data["user"] = UserSerializer(
+                request.user,
+                context=self.get_context()
+            ).data
+        return data
+
     def post(self, request, format=None):
         token_limit_per_user = self.get_token_limit_per_user()
         if token_limit_per_user is not None:
@@ -45,19 +63,7 @@ class LoginView(APIView):
         instance, token = AuthToken.objects.create(request.user, token_ttl)
         user_logged_in.send(sender=request.user.__class__,
                             request=request, user=request.user)
-        UserSerializer = self.get_user_serializer_class()
-        datetime_format = self.get_expiry_datetime_format()
-
-        data = {
-            'expiry': DateTimeField(
-                format=datetime_format).to_representation(instance.expiry),
-            'token': token
-        }
-        if UserSerializer is not None:
-            data["user"] = UserSerializer(
-                request.user,
-                context=self.get_context()
-            ).data
+        data = self.get_post_response_data(request, token, instance)
         return Response(data)
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='4.0.0',
+    version='4.0.1',
     description='Authentication for django rest framework',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Replaces #179 
Fixes #171 
Fixes #178 

- Now expiry format defaults to whatever is used Django REST framework
- This behavior can be overriden via `EXPIRY_DATETIME_FORMAT` setting
- fully customizable expiry format via `format_expiry_datetime`
- fully customizable response payload via `get_post_response_data`