### PR TITLE
knox: handle race condition on concurrent logout call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+- Fix race condition on concurrent logout call
+
 ## 4.1.0
 
 - Expiry format now defaults to whatever is used Django REST framework

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ deps =
     django22: Django>=2.2,<2.3
     django-nose
     markdown<3.0
+    mock
     isort
     djangorestframework
     freezegun


### PR DESCRIPTION
With AUTO_REFRESH enabled authentication is racing against token removal of logout. If a token gets removed updating its expiry would led to a DatabaseError raised by the Django ORM.
    
Fix that by ignoring DatabaseError exception returned by renew_token so that the last request will get a AuthenticationFailed exception instead of a 500 error.