### PR TITLE
correct language about token hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ default implementation:
     an attacker unrestricted access to an account with a token if the
     database were compromised.
 
-    Knox tokens are only stored in an encrypted form. Even if the
+    Knox tokens are only stored in a secure hash form (like a password). Even if the
     database were somehow stolen, an attacker would not be able to log
     in with the stolen credentials.
 


### PR DESCRIPTION
I believe tokens are stored in a hashed form, not an encrypted form in the database. This change updates the README to reflect this distinction.