### PR TITLE
Raise AuthenticationFailed for one all one word headers, not just "Token"

### DIFF
--- a/knox/auth.py
+++ b/knox/auth.py
@@ -37,7 +37,10 @@ class TokenAuthentication(BaseAuthentication):
         auth = get_authorization_header(request).split()
         prefix = knox_settings.AUTH_HEADER_PREFIX.encode()
 
-        if not auth or auth[0].lower() != prefix.lower():
+        if not auth:
+            return None
+        if auth[0].lower() != prefix.lower():
+            # Authorization header is possibly for another backend
             return None
         if len(auth) == 1:
             msg = _('Invalid token header. No credentials provided.')


### PR DESCRIPTION
The current code in authenticate() seems to try to raise
AuthenticationFailed if the authentication header is just one word:

        if not auth or auth[0].lower() != prefix.lower():
            return None
        if len(auth) == 1:
            msg = _('Invalid token header. No credentials provided.')
            raise exceptions.AuthenticationFailed(msg)

However, if `auth` has just one item, `auth[0].lower()` is not likely
to equal the prefix. So probably we'll just return None.

This commit tries to fix that by testing
`auth[0].lower() != prefix.lower()` only after we've checked that we
received the correct number of words in the authentication header.