### PR TITLE
Remove unused User definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
   include:
     - python: "2.7"
       env: TOX_ENVS=py27-django111
-    - python: "3.4"
-      env: TOX_ENVS=py34-django111,py34-django20
     - python: "3.5"
       env: TOX_ENVS=py35-django111,py35-django20,py35-django20,py35-django21
     - python: "3.6"

--- a/knox/auth.py
+++ b/knox/auth.py
@@ -6,7 +6,6 @@ except ImportError:
 
 import binascii
 
-from django.contrib.auth import get_user_model
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 from rest_framework import exceptions
@@ -18,8 +17,6 @@ from knox.crypto import hash_token
 from knox.models import AuthToken
 from knox.settings import CONSTANTS, knox_settings
 from knox.signals import token_expired
-
-User = get_user_model()
 
 
 class TokenAuthentication(BaseAuthentication):

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
     isort
     flake8,
-    py{27,34,35,36}-django111,
-    py{34,35,36}-django20,
+    py{27,35,36}-django111,
+    py{35,36}-django20,
     py{35,36,37}-django21,
     py{35,36,37}-django22,
 


### PR DESCRIPTION
I was triggered to look into this by https://github.com/James1345/django-rest-knox/issues/194. It looks like the reporter of that issue has had some kind of misconfiguration, and that issue can be closed. 

But it does look like the definition of `User` is superfluous here.