### PR TITLE
Stop testing with Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
   include:
     - python: "2.7"
       env: TOX_ENVS=py27-django111
-    - python: "3.4"
-      env: TOX_ENVS=py34-django111,py34-django20
     - python: "3.5"
       env: TOX_ENVS=py35-django111,py35-django20,py35-django20,py35-django21
     - python: "3.6"

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
     isort
     flake8,
-    py{27,34,35,36}-django111,
-    py{34,35,36}-django20,
+    py{27,35,36}-django111,
+    py{35,36}-django20,
     py{35,36,37}-django21,
     py{35,36,37}-django22,
 


### PR DESCRIPTION
Python 3.4 is end-of-life (https://www.python.org/downloads/release/python-340/), we can stop supporting it.

Some builds (https://travis-ci.org/James1345/django-rest-knox/jobs/647661512, https://travis-ci.org/James1345/django-rest-knox/jobs/647660925) are now failing because `PyYAML requires Python '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*' but the running Python is 3.4.8`