### PR TITLE
Add label as optional field to identify a token

### DIFF
--- a/knox/models.py
+++ b/knox/models.py
@@ -31,6 +31,9 @@ class AuthToken(models.Model):
         max_length=CONSTANTS.DIGEST_LENGTH, primary_key=True)
     token_key = models.CharField(
         max_length=CONSTANTS.TOKEN_KEY_LENGTH, db_index=True)
+    # optional (but handy) human name to identify a token
+    label = models.CharField(
+        max_length=32, null=True, blank=True)
     salt = models.CharField(
         max_length=CONSTANTS.SALT_LENGTH, unique=True)
     user = models.ForeignKey(User, null=False, blank=False,
@@ -39,4 +42,4 @@ class AuthToken(models.Model):
     expiry = models.DateTimeField(null=True, blank=True)
 
     def __str__(self):
-        return '%s : %s' % (self.digest, self.user)
+        return '%s %s : %s' % (self.label, self.digest, self.user)


### PR DESCRIPTION
Hi! 

would it be possible to include optional label field to the model? I use knox auth in papermerge project and I find it confusing to identify tokens by their digest. From user's point of view, digests and tokens look similar.

[Here is the use case.](https://papermerge.readthedocs.io/en/latest/rest_api.html#use-the-token)

Note that tokens are **not** created in login view (I dont use knox' login view at all).