### PR TITLE
fix django warnings - ugettext_lazy is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ More information can be found in the
 
 If you need to debug a test locally and if you have [docker](https://www.docker.com/) installed:
 
-simply run the ``./docker-run-test.sh`` script and it will run the test suite in every Python /
+simply run the ``./docker-run-tests.sh`` script and it will run the test suite in every Python /
 Django versions.
 
 You could also simply run regular ``tox`` in the root folder as well, but that would make testing the matrix of

--- a/knox/auth.py
+++ b/knox/auth.py
@@ -7,7 +7,7 @@ except ImportError:
 import binascii
 
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions
 from rest_framework.authentication import (
     BaseAuthentication, get_authorization_header,


### PR DESCRIPTION
```
RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
```

See: https://docs.djangoproject.com/en/3.0/_modules/django/utils/translation/