### PR TITLE
Use hashlib

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,27 +2,8 @@
 
 ## Requirements
 
-Knox depends on `cryptography` to provide bindings to `OpenSSL` for token generation
-This requires the OpenSSL build libraries to be available.
-
-### Windows
-Cryptography is a statically linked build, no extra steps are needed.
-
-### Linux
-`cryptography` should build very easily on Linux provided you have a C compiler,
-headers for Python (if you’re not using `pypy`), and headers for the OpenSSL and
-`libffi` libraries available on your system.
-
-Debian and Ubuntu:
-```bash
-sudo apt-get install build-essential libssl-dev libffi-dev python3-dev python-dev
-```
-
-Fedora and RHEL-derivatives:
-```bash
-sudo yum install gcc libffi-devel python-devel openssl-devel
-```
-For other systems or problems, see the [cryptography installation docs](https://cryptography.io/en/latest/installation/)
+Knox depends on pythons internal library `hashlib` to provide bindings to `OpenSSL` or uses
+an internal implementation of hashing algorithms for token generation.
 
 ## Installing Knox
 Knox should be installed with pip
@@ -59,7 +40,7 @@ REST_FRAMEWORK = {
 
 - If you set TokenAuthentication as the only default authentication class on the second step, [override knox's LoginView](auth.md#global-usage-on-all-views) to accept another authentication method and use it instead of knox's default login view.
 
-- Apply the migrations for the models
+- Apply the migrations for the models.
 
 ```bash
 python manage.py migrate

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -11,7 +11,7 @@ Example `settings.py`
 from datetime import timedelta
 from rest_framework.settings import api_settings
 REST_KNOX = {
-  'SECURE_HASH_ALGORITHM': 'cryptography.hazmat.primitives.hashes.SHA512',
+  'SECURE_HASH_ALGORITHM': 'hashlib.sha512',
   'AUTH_TOKEN_CHARACTER_LENGTH': 64,
   'TOKEN_TTL': timedelta(hours=10),
   'USER_SERIALIZER': 'knox.serializers.UserSerializer',
@@ -30,14 +30,13 @@ token storage.
 
 By default, Knox uses SHA-512 to hash tokens in the database.
 
-`cryptography.hazmat.primitives.hashes.Whirlpool` is an acceptable alternative setting
-for production use.
+`hashlib.sha3_512` is an acceptable alternative setting for production use.
 
 ### Tests
-SHA-512 and Whirlpool are secure, however, they are slow. This should not be a
+SHA-512 and SHA3-512 are secure, however, they are slow. This should not be a
 problem for your users, but when testing it may be noticeable (as test cases tend
 to use many more requests much more quickly than real users). In testing scenarios
-it is acceptable to use `MD5` hashing.(`cryptography.hazmat.primitives.hashes.MD5`)
+it is acceptable to use `MD5` hashing (`hashlib.md5`).
 
 MD5 is **not secure** and must *never* be used in production sites.
 

--- a/knox/crypto.py
+++ b/knox/crypto.py
@@ -1,12 +1,9 @@
 import binascii
 from os import urandom as generate_bytes
 
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import hashes
-
 from knox.settings import knox_settings
 
-sha = knox_settings.SECURE_HASH_ALGORITHM
+hash_func = knox_settings.SECURE_HASH_ALGORITHM
 
 
 def create_token_string():
@@ -15,14 +12,12 @@ def create_token_string():
     ).decode()
 
 
-def hash_token(token):
-    '''
+def hash_token(token: str) -> str:
+    """
     Calculates the hash of a token.
-    input is unhexlified
-
-    token must contain an even number of hex digits or a binascii.Error
-    exception will be raised
-    '''
-    digest = hashes.Hash(sha(), backend=default_backend())
+    Token must contain an even number of hex digits or
+    a binascii.Error exception will be raised.
+    """
+    digest = hash_func()
     digest.update(binascii.unhexlify(token))
-    return binascii.hexlify(digest.finalize()).decode()
+    return digest.hexdigest()

--- a/knox/settings.py
+++ b/knox/settings.py
@@ -7,7 +7,7 @@ from rest_framework.settings import APISettings, api_settings
 USER_SETTINGS = getattr(settings, 'REST_KNOX', None)
 
 DEFAULTS = {
-    'SECURE_HASH_ALGORITHM': 'cryptography.hazmat.primitives.hashes.SHA512',
+    'SECURE_HASH_ALGORITHM': 'hashlib.sha512',
     'AUTH_TOKEN_CHARACTER_LENGTH': 64,
     'TOKEN_TTL': timedelta(hours=10),
     'USER_SERIALIZER': None,

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ setup(
     install_requires=[
         'django>=3.2',
         'djangorestframework',
-        'cryptography',
     ],
 
     # List additional groups of dependencies here (e.g. development

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,6 @@ deps =
     djangorestframework
     freezegun
     mkdocs
-    cryptography
     pytest-django
     setuptools
     twine


### PR DESCRIPTION
## Purpose

Remove dependency to extra library which maybe require compiling.
Internal hashlib library has the same function. For default sha512 it does not require openssl. If openssl is available it is used for better performance.

## Reference

Issue #199

## Notice

~~This pr includes #225 because it does not work on old python 2.7.~~