### PR TITLE
Fix Django deprecation warning about Signals

### DIFF
--- a/knox/signals.py
+++ b/knox/signals.py
@@ -1,3 +1,3 @@
 import django.dispatch
 
-token_expired = django.dispatch.Signal(providing_args=["username", "source"])
+token_expired = django.dispatch.Signal()


### PR DESCRIPTION
Recently, Django has started throwing some deprecation warnings.  `Signal` no longer has a `providing_args` parameter.

```
/lib/python3.8/site-packages/knox/signals.py:3: RemovedInDjango40Warning: The providing_args argument is deprecated. As it is purely documentational, it has no replacement. If you rely on this argument as documentation, you can move the text to a code comment or docstring.
    token_expired = django.dispatch.Signal(providing_args=["username", "source"])
```

Closes #232 