### PR TITLE
Fixed REST_KNOX example typo in settings.md

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -17,7 +17,7 @@ REST_KNOX = {
   'USER_SERIALIZER': 'knox.serializers.UserSerializer',
   'TOKEN_LIMIT_PER_USER': None,
   'AUTO_REFRESH': False,
-  'EXPIRY_DATETIME_FORMAT': api_settings.DATETME_FORMAT,
+  'EXPIRY_DATETIME_FORMAT': api_settings.DATETIME_FORMAT,
 }
 #...snip...
 ```


### PR DESCRIPTION
Fixed a typo in the `settings.py` example. Value for key ‘EXPIRY_DATETIME_FORMAT' setting was missing a character.