### PR TITLE
Fix migrate zero problem on django 4.0.4

### DIFF
--- a/knox/migrations/0006_auto_20160818_0932.py
+++ b/knox/migrations/0006_auto_20160818_0932.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(cleanup_tokens),
+        migrations.RunPython(cleanup_tokens, reverse_code=migrations.RunPython.noop),
         migrations.AlterField(
             model_name='authtoken',
             name='token_key',


### PR DESCRIPTION
fix  django.db.migrations.exceptions.IrreversibleError: Operation <RunPython <function cleanup_tokens at 0x0000027CCB764820>> in knox.0006_auto_20160818_0932 is not reversible error when python manage.py migrate knox zero