### PR TITLE
Add cookie-based authentication feature

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -101,6 +101,15 @@ The default is `knox.AuthToken`
 ## TOKEN_PREFIX
 This is the prefix for the generated token that is used in the Authorization header. The default is just an empty string.
 It can be up to `CONSTANTS.MAXIMUM_TOKEN_PREFIX_LENGTH` long.
+## ENABLE_COOKIE_AUTH
+This defines if the authentication will be done using a `HTTP-only` Cookie.
+The default is `False`
+## AUTH_COOKIE_SALT
+This is the Salt `(String)` that is added to better store and secure token value inside Cookies
+the default value is `"knox"` and it can be up to `CONSTANTS.MAXIMUM_SALT_LENGTH` long.
+## AUTH_COOKIE_KEY
+This is the `Cookie` key of the token. The default is `knox`.
+It can be up to `CONSTANTS.MAXIMUM_COOKIE_KEY_LENGTH` long.
 
 # Constants `knox.settings`
 Knox also provides some constants for information. These must not be changed in
@@ -118,3 +127,9 @@ This is the length of the digest that will be stored in the database for each to
 
 ## MAXIMUM_TOKEN_PREFIX_LENGTH
 This is the maximum length of the token prefix.
+
+## MAXIMUM_COOKIE_KEY_LENGTH
+This is the maximum length of the cookie `key`
+
+## MAXIMUM_SALT_LENGTH
+This is the maximum length of  Salt `(String)` that encode token value inside the cookie.

--- a/knox/settings.py
+++ b/knox/settings.py
@@ -18,6 +18,9 @@ DEFAULTS = {
     'EXPIRY_DATETIME_FORMAT': api_settings.DATETIME_FORMAT,
     'TOKEN_MODEL': getattr(settings, 'KNOX_TOKEN_MODEL', 'knox.AuthToken'),
     'TOKEN_PREFIX': '',
+    'ENABLE_COOKIE_AUTH':False,
+    'AUTH_COOKIE_SALT':"knox",
+    'AUTH_COOKIE_KEY': 'knox',
 }
 
 IMPORT_STRINGS = {
@@ -35,6 +38,10 @@ def reload_api_settings(*args, **kwargs):
         knox_settings = APISettings(value, DEFAULTS, IMPORT_STRINGS)
         if len(knox_settings.TOKEN_PREFIX) > CONSTANTS.MAXIMUM_TOKEN_PREFIX_LENGTH:
             raise ValueError("Illegal TOKEN_PREFIX length")
+        if len(knox_settings.AUTH_COOKIE_KEY) > CONSTANTS.MAXIMUM_COOKIE_KEY_LENGTH:
+            raise ValueError("unauthorized COOKIE_KEY length")
+        if len(knox_settings.AUTH_COOKIE_SALT) > CONSTANTS.MAXIMUM_SALT_LENGTH:
+            raise ValueError("unauthorized COOKIE_SALT length")
 
 
 setting_changed.connect(reload_api_settings)
@@ -47,6 +54,8 @@ class CONSTANTS:
     TOKEN_KEY_LENGTH = 15
     DIGEST_LENGTH = 128
     MAXIMUM_TOKEN_PREFIX_LENGTH = 10
+    MAXIMUM_SALT_LENGTH=10
+    MAXIMUM_COOKIE_KEY_LENGTH=8
 
     def __setattr__(self, *args, **kwargs):
         raise Exception('''


### PR DESCRIPTION
HI 

This feature will allows ,when enabled ,the authentification through a http-only cookie that is stored on a specified domain and signed using a Salt key .
 I hope this will be very useful specially for those who wanted a COOKIE-BASED AUTH for better security  and answers for issue #269 .
@James1345 @belugame 
i would be very grateful if you could take a look at my PR and give feedback