### PR TITLE
Fix for n+1 query on AuthToken.user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.3
+- Fix for Potential n+1 query detected on AuthToken.user
+
 ## 5.0.2
 - Implement AUTO_REFRESH_MAX_TTL to limit total token lifetime when AUTO_REFRESH = True
 

--- a/knox/auth.py
+++ b/knox/auth.py
@@ -60,7 +60,7 @@ class TokenAuthentication(BaseAuthentication):
         msg = _('Invalid token.')
         token = token.decode("utf-8")
         for auth_token in get_token_model().objects.filter(
-                token_key=token[:CONSTANTS.TOKEN_KEY_LENGTH]):
+                token_key=token[:CONSTANTS.TOKEN_KEY_LENGTH]).select_related('user'):
             if self._cleanup_token(auth_token):
                 continue
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -229,6 +229,19 @@ class TokenAuthenticationTestCase(BaseTestCase):
             auth_token.token_key,
         )
 
+    def test_token_auth_n_plus_one(self):
+        self.assertEqual(AuthToken.objects.count(), 0)
+        _, token = AuthToken.objects.create(self.user)
+        rf = APIRequestFactory()
+        request = rf.get('/')
+        request.META = {'HTTP_AUTHORIZATION': f'Token {token}'}
+        with self.assertNumQueries(2):
+            (self.user, auth_token) = TokenAuthentication().authenticate(request)
+            self.assertEqual(
+                token[:CONSTANTS.TOKEN_KEY_LENGTH],
+                auth_token.token_key,
+            )
+
     def test_authorization_header_empty(self):
         rf = APIRequestFactory()
         request = rf.get('/')


### PR DESCRIPTION
Fix for Potential n+1 query detected on `AuthToken.user`
<img width="796" alt="Screenshot 2025-02-15 at 10 54 58 PM" src="https://github.com/user-attachments/assets/d16328c8-e57e-4af9-aa3f-0f489306397a" />
