### PR TITLE
Fix migrations so that migrate knox zero is possible

### DIFF
--- a/knox/migrations/0003_auto_20150916_1526.py
+++ b/knox/migrations/0003_auto_20150916_1526.py
@@ -4,6 +4,22 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 
 
+def populate_salt_field_with_dummy_data(apps, schema_editor):
+    """we just populate salt field with index to make it unique"""
+
+    AuthToken = apps.get_model("knox", "AuthToken")
+    for index, token in enumerate(AuthToken.objects.all()):
+        token.salt = index
+        token.save(update_fields=["salt"])
+
+
+def delete_all_rows(apps, schema_editor):
+    """Since digest field is the pk best way to revert migrations is just to delete all Auth token rows"""
+
+    AuthToken = apps.get_model("knox", "AuthToken")
+    AuthToken.objects.using(schema_editor.connection.alias).all().delete()
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -19,6 +35,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='authtoken',
             name='salt',
-            field=models.CharField(unique=True, max_length=16),
+            field=models.CharField(max_length=16, null=True),
         ),
     ]

--- a/knox/migrations/0003_auto_20150916_1526.py
+++ b/knox/migrations/0003_auto_20150916_1526.py
@@ -28,13 +28,17 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AlterField(
-            model_name='authtoken',
-            name='digest',
+            model_name="authtoken",
+            name="digest",
             field=models.CharField(primary_key=True, serialize=False, max_length=128),
         ),
+        migrations.RunPython(migrations.RunPython.noop, delete_all_rows),
         migrations.AlterField(
-            model_name='authtoken',
-            name='salt',
+            model_name="authtoken",
+            name="salt",
             field=models.CharField(max_length=16, null=True),
+        ),
+        migrations.RunPython(
+            migrations.RunPython.noop, populate_salt_field_with_dummy_data
         ),
     ]

--- a/knox/migrations/0009_extend_authtoken_field.py
+++ b/knox/migrations/0009_extend_authtoken_field.py
@@ -3,6 +3,18 @@
 from django.db import migrations, models
 
 
+def clear_token_keys(apps, schema_editor):
+    """
+    Clears all token values so that when reverting migration
+    and the field token_key max_length gets changed from 25 to 8 it doesn't trigger DataError
+    """
+
+    AuthToken = apps.get_model("knox", "AuthToken")
+    AuthToken.objects.using(schema_editor.connection.alias).update(
+        token_key=""
+    )  # Clears all token values
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -15,4 +27,5 @@ class Migration(migrations.Migration):
             name="token_key",
             field=models.CharField(db_index=True, max_length=25),
         ),
+        migrations.RunPython(migrations.RunPython.noop, clear_token_keys),
     ]


### PR DESCRIPTION
Following this issue https://github.com/jazzband/django-rest-knox/issues/368 I wanted to help since it was not possible to reverse migrations especially when there is rows in the database