### PR TITLE
Add support for Django 5.2, 6.0 and Python 3.13, 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.4
+- Add support for Django 6.0 and Python 3.13, 3.14
+
 ## 5.0.3
 - Fix for Potential n+1 query detected on AuthToken.user
 

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,8 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
     ],
 
     # What does your project relate to?

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,8 @@
 envlist =
     py{38,39,310,311,312}-django42,
     py{310,311,312}-django50,
+    py{310,311,312,313}-django52,
+    py{312,313,314}-django60,
 
 [testenv]
 commands =
@@ -14,6 +16,8 @@ setenv =
 deps =
     django42: Django>=4.2,<4.3
     django50: Django>=5.0,<5.1
+    django52: Django>=5.2,<5.3
+    django60: Django>=6.0,<6.1
     markdown>=3.0
     djangorestframework
     freezegun
@@ -31,3 +35,5 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
+    3.14: py314


### PR DESCRIPTION
We're upgrading to Django 6.0 and noticed knox doesn't officially support it yet, so I figured I'd open this PR to add support for Python 3.13, 3.14 and Django 5.2, 6.0.

We've been using knox in production for over two years alongside other jazzband-maintained packages, happy to give back with a contribution. Thanks for all the great work!